### PR TITLE
Fix routing paths to not use DEPLOYMENTS_DIR env variable

### DIFF
--- a/server-configs/apache/config-modules/identity.conf
+++ b/server-configs/apache/config-modules/identity.conf
@@ -9,4 +9,4 @@
 ServerAdmin ni@aefeup.pt
 ServerName ni.fe.up.pt
 ServerAlias www.ni.fe.up.pt
-DocumentRoot ${DEPLOYMENTS_DIR}/Website-NIAEFEUP
+DocumentRoot /home/ni/git/Website-NIAEFEUP

--- a/server-configs/apache/config-modules/routing.conf
+++ b/server-configs/apache/config-modules/routing.conf
@@ -12,15 +12,15 @@ RewriteRule ^/?(.*) %{REQUEST_SCHEME}://ni.fe.up.pt/tts/new%{REQUEST_URI}
 ProxyPass /tts/api http://localhost:5000
 
 ProxyPass /tts/old !
-Alias /tts/old ${DEPLOYMENTS_DIR}/Timetable-Selector
+Alias /tts/old /home/ni/git/Timetable-Selector
 
 ProxyPass /tts/new !
-Alias /tts/new ${DEPLOYMENTS_DIR}/TimeTable-Selector-Web/dist
+Alias /tts/new /home/ni/git/TimeTable-Selector-Web/dist
 
 ProxyPass /tts !
-Alias /tts ${DEPLOYMENTS_DIR}/TimeTable-Selector-Web/dist
+Alias /tts /home/ni/git/TimeTable-Selector-Web/dist
 ProxyPass /TTS !
-Alias /TTS ${DEPLOYMENTS_DIR}/TimeTable-Selector-Web/dist
+Alias /TTS /home/ni/git/TimeTable-Selector-Web/dist
 
 ProxyPass /semana-inf !
 Alias /semana-inf /home/ni/git/informatics-week-website-2017


### PR DESCRIPTION
This variable was removed in a previous commit in #1 but this reference was left behind