### PR TITLE
Fix wrong tts port allocation

### DIFF
--- a/server-configs/apache/config-modules/routing.conf
+++ b/server-configs/apache/config-modules/routing.conf
@@ -9,7 +9,7 @@ RewriteCond %{HTTP_REFERER} https?://ni.fe.up.pt/(tts|TTS)/?
 RewriteCond %{REQUEST_URI} !/tts/(new|api)?.*
 RewriteRule ^/?(.*) %{REQUEST_SCHEME}://ni.fe.up.pt/tts/new%{REQUEST_URI}
 
-ProxyPass /tts/api http://localhost:5000
+ProxyPass /tts/api http://localhost:8080
 
 ProxyPass /tts/old !
 Alias /tts/old /home/ni/git/Timetable-Selector


### PR DESCRIPTION
For some reason, `/tts/api` was being mapped to port 5000, but the api is running in port 8080.