### PR TITLE
Add nijobs-fe experimental release

### DIFF
--- a/deployments/project-configs.sh
+++ b/deployments/project-configs.sh
@@ -23,6 +23,9 @@ project_dotenv_location[nijobs-fe---master]='/home/ni/niployments/deployments/en
 ## nijobs-fe staging
 project_port[nijobs-fe---develop]=4002
 project_dotenv_location[nijobs-fe---develop]='/home/ni/niployments/deployments/env-files/nijobs-fe/develop/.env'
+## nijobs-fe experimental (pre-develop, "true staging" vs staging=beta/nightly)
+project_port[nijobs-fe---experimental]=4003
+project_dotenv_location[nijobs-fe---experimental]='/home/ni/niployments/deployments/env-files/nijobs-fe/experimental/.env'
 
 # nijobs-be
 project_port[nijobs-be---master]=4010

--- a/deployments/spam-deploys.sh
+++ b/deployments/spam-deploys.sh
@@ -16,10 +16,17 @@ if [[ ! -d "$spam_deploys_curr_dir" ]]; then spam_deploys_curr_dir="${0%/*}"; fi
 # Configure the projects to automatically deploy below here
 
 # nijobs-be
-("$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-be master; "$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-be develop) &
+(
+    "$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-be master;
+    "$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-be develop
+) &
 
 # nijobs-fe
-("$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-fe master; "$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-fe develop) &
+(
+    "$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-fe master;
+    "$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-fe develop;
+    "$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-fe experimental
+) &
 
 # NIAEFEUP-Website
 # Currently on hold until some changes are done

--- a/server-configs/apache/config-modules/routing.conf
+++ b/server-configs/apache/config-modules/routing.conf
@@ -25,6 +25,8 @@ Alias /TTS /home/ni/git/TimeTable-Selector-Web/dist
 ProxyPass /semana-inf !
 Alias /semana-inf /home/ni/git/informatics-week-website-2017
 
+ProxyPass /lab/nijobs http://localhost:4003
+
 ProxyPass /st4g1ng/nijobs/api http://localhost:4011
 ProxyPass /st4g1ng/nijobs http://localhost:4002
 


### PR DESCRIPTION
Adds an experimental release at `/lab/nijobs` for nijobs-fe. Useful for forcing things onto the production server (basically a _"true"_ staging deploy, instead of just a beta/nightly build one).