### PR TITLE
 Temporarily remove website from deploys

### DIFF
--- a/deployments/spam-deploys.sh
+++ b/deployments/spam-deploys.sh
@@ -28,11 +28,13 @@ if [[ ! -d "$spam_deploys_curr_dir" ]]; then spam_deploys_curr_dir="${0%/*}"; fi
     "$spam_deploys_curr_dir/deploy.sh" --cron-mode nijobs-fe experimental
 ) &
 
-# Website-NIAEFEUP
-(
-    "$spam_deploys_curr_dir/deploy.sh" --cron-mode Website-NIAEFEUP master;
+# Website-NIAEFEUP 
+# Currently on hold until a solution for uploaded resources  
+# is reached to store them outside the container
+# (
+    # "$spam_deploys_curr_dir/deploy.sh" --cron-mode Website-NIAEFEUP master;
     # "$spam_deploys_curr_dir/deploy.sh" --cron-mode Website-NIAEFEUP develop
-) &
+# ) &
 
 # tts-fe
 # Currently on hold until the React port is done


### PR DESCRIPTION
Due to problems regarding the fact that resources are stored inside the container, our website must for now be run locally instead of inside of a container. This should be a temporary measure as we figure out a solution for this. 