### PR TITLE
Add X-Forwarded-Proto header

### DIFF
--- a/server-configs/apache/config-modules/routing.conf
+++ b/server-configs/apache/config-modules/routing.conf
@@ -9,6 +9,13 @@ RewriteCond %{HTTP_REFERER} https?://ni.fe.up.pt/(tts|TTS)/?
 RewriteCond %{REQUEST_URI} !/tts/(api)?.*
 RewriteRule ^/?(.*) %{REQUEST_SCHEME}://ni.fe.up.pt/tts%{REQUEST_URI}
 
+# Needed in order to make secure cookies work in https
+# The following might give some context 
+#   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+#   https://github.com/expressjs/session/issues/281
+#   https://github.com/NIAEFEUP/niployments/pull/23 (The PR making this change)
+RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}
+
 ProxyPass /tts/api http://localhost:8080
 
 ProxyPass /tts http://localhost:3100


### PR DESCRIPTION
Currently, in [NIJobs](https://github.com/NIAEFEUP/nijobs-be/), secure cookies are not working in the production server and according to https://github.com/expressjs/session/issues/28, we need to set the X-Forwarded-Proto header, so that the server knows who made the request (instead of the apache server which is actually a reverse proxy)

The Proxy Pass directive was already setting X-Forwarded-For, X-Forwarded-Host, and X-Forwarded-Server, so in theory, this change should suffice on the niployments end.