### PR TITLE
Added X-Forwarded-Proto header

### DIFF
--- a/server-configs/apache/config-modules/routing.conf
+++ b/server-configs/apache/config-modules/routing.conf
@@ -13,8 +13,8 @@ RewriteRule ^/?(.*) %{REQUEST_SCHEME}://ni.fe.up.pt/tts%{REQUEST_URI}
 # The following might give some context 
 #   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
 #   https://github.com/expressjs/session/issues/281
-#   https://github.com/NIAEFEUP/niployments/pull/23 (The PR making this change)
-RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}
+#   https://github.com/NIAEFEUP/niployments/pull/24 (The PR making this change)
+RequestHeader set X-Forwarded-Proto expr=%{REQUEST_SCHEME}
 
 ProxyPass /tts/api http://localhost:8080
 


### PR DESCRIPTION
This is actually a fix after #23, but I am replicating the context here. This is proven to work this time, since I manually deployed the changes in order to test it.

From #23:

> Currently, in [NIJobs](https://github.com/NIAEFEUP/nijobs-be/), secure cookies are not working in the production server and according to https://github.com/expressjs/session/issues/28, we need to set the X-Forwarded-Proto header, so that the server knows who made the request (instead of the apache server which is actually a reverse proxy)
> 
> The Proxy Pass directive was already setting X-Forwarded-For, X-Forwarded-Host, and X-Forwarded-Server, so in theory, this change should suffice on the niployments end.