### PR TITLE
Implement Health Checks w/ Rollback

### DIFF
--- a/deployments/.gitignore
+++ b/deployments/.gitignore
@@ -4,6 +4,7 @@
 !deploy.sh
 !deploy-types.sh
 !spam-deploys.sh
+!health-checker.sh
 !README.md
 # Also, the project configurations!
 !project-configs.sh

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -21,6 +21,10 @@ The `port` is mandatory, but the `env_file_path` and `docker_flags` are optional
 
 The paths provided in the said file **MUST** be **absolute** (trust me you don't want to handle bash's path spaghetti :upside_down_face: :wink:).
 
+#### Deployment Health Checks and Rollbacks
+
+You can set a `project_health_check_url` per project, which will be used to assert the service is running properly after deployment. The deploy script will query the url (using cURL) every 10 seconds until it returns HTTP 200, for a maximum of 5 minutes. It is advised that you pass a url served by the respective service which only returns 200 when the service is in good operating state. This variable is optional. If it is not provided, the health check will not be done. 
+
 ## Notes
 
 `docker system prune` should be run periodically to clean up dangling images and containers. The deployment scripts attempt to minimize the number of these but some are left on purpose due to speeding up multi-stage builds.

--- a/deployments/deploy.sh
+++ b/deployments/deploy.sh
@@ -24,7 +24,7 @@ branch="${2:-master}"
 # shellcheck source=utils/utils.sh
 source "$deploy_curr_dir/../utils/utils.sh"
 
-# Getting project configurations (configured_projects, project_port and project_dotenv_location)
+# Getting project configurations (configured_projects, project_port, project_dotenv_location and project_health_check_url)
 # shellcheck source=deployments/project-configs.sh
 source "$deploy_curr_dir/project-configs.sh"
 
@@ -111,7 +111,7 @@ set +e
     echo
     
     # Passing in the configs from ./project-configs.sh. dotenv_location and docker_flags might not be set so sending instead an empty variable ("") so that the 'unbound variable' error does not occur
-    deploy_default "$project" "$branch" "${project_port[$project---$branch]}" "${project_dotenv_location[$project---$branch]:-}" "${project_docker_flags[$project---$branch]:-}"
+    deploy_default "$project" "$branch" "${project_port[$project---$branch]}" "${project_dotenv_location[$project---$branch]:-}" "${project_docker_flags[$project---$branch]:-}" "${project_health_check_url[$project---$branch]:-}"
 ) 2>&1 | tee "$logfile"
 
 # This gets the return status of the first element of the previous pipe, aka the subshell executing the deployment commands

--- a/deployments/health-checker.sh
+++ b/deployments/health-checker.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+### Check for service availability after container startup
+### To be used by deploy-types.sh
+
+# See https://sipb.mit.edu/doc/safe-shell/
+set -ueo pipefail
+
+# Calls a given url and returns 0 if the response status is HTTP 200, 1 otherwise
+# Arguments: url - URL to call
+function is_healthy_url() {
+    local url="$1"
+
+    local response_code
+    response_code="$(curl -s -o /dev/null -w "%{http_code}" "$url")"
+
+    if [ "$response_code" == "200" ]; then
+        echo 0
+    else
+        echo 1
+    fi
+
+    return 0
+}
+
+# Periodically calls a given url until it returns HTTP 200, or max retries is reached. 
+# Returns 0 if health check was successful, 1 otherwise
+# Arguments: url - URL to call
+function health_checker() {
+    local url="$1"
+
+    # According to 1 retry every 10 seconds, this will try for 5 minutes
+    local MAX_ATTEMPTS=26
+    local RETRY_INTERVAL_SECONDS=1
+
+    local is_healthy_result=1
+    local retry_count=0
+
+    while [ "$is_healthy_result" -ne 0 ]
+    do
+        
+        if [ "$retry_count" -eq "$MAX_ATTEMPTS" ]; then
+            break
+        fi
+ 
+        echo -e "[Health Checker] Attempt $retry_count\n"
+
+        is_healthy_result="$(is_healthy_url "$url")"
+
+        if [ "$is_healthy_result" -eq 0 ]; then
+            echo -e "[Health Checker] Health Check successfull!\n"
+            break
+        fi
+
+        echo -e "[Health Checker] Attempt ${retry_count} failed.\n"
+        retry_count=$((retry_count+1))
+        
+        sleep $RETRY_INTERVAL_SECONDS
+    done
+
+    if [ "$is_healthy_result" -ne 0 ]; then
+        echo -e "[Health Checker] Max number of retries reached. Health Check failed.\n"
+    fi
+
+    return "$is_healthy_result"
+}
+
+export -f health_checker

--- a/deployments/health-checker.sh
+++ b/deployments/health-checker.sh
@@ -19,8 +19,6 @@ function is_healthy_url() {
     else
         echo 1
     fi
-
-    return 0
 }
 
 # Periodically calls a given url until it returns HTTP 200, or max retries is reached. 
@@ -30,8 +28,8 @@ function health_checker() {
     local url="$1"
 
     # According to 1 retry every 10 seconds, this will try for 5 minutes
-    local MAX_ATTEMPTS=26
-    local RETRY_INTERVAL_SECONDS=1
+    local MAX_ATTEMPTS=31
+    local RETRY_INTERVAL_SECONDS=10
 
     local is_healthy_result=1
     local retry_count=0

--- a/deployments/project-configs.sh
+++ b/deployments/project-configs.sh
@@ -39,12 +39,12 @@ project_dotenv_location[nijobs-fe---experimental]='/home/ni/niployments/deployme
 project_port[nijobs-be---master]=4010
 project_dotenv_location[nijobs-be---master]='/home/ni/niployments/deployments/env-files/nijobs-be/master/.env.local'
 project_docker_flags[nijobs-be---master]='-v /home/ni/niployments/deployments/volumes-data/nijobs:/usr/src/app/static'
-project_health_check_url[nijobs-be---master]='https://localhost:${project_port[nijobs-be---master]}/'
+project_health_check_url[nijobs-be---master]="https://localhost:${project_port[nijobs-be---master]}/"
 ## nijobs-be staging
 project_port[nijobs-be---develop]=4011
 project_dotenv_location[nijobs-be---develop]='/home/ni/niployments/deployments/env-files/nijobs-be/develop/.env.local'
 project_docker_flags[nijobs-be---develop]='-v /home/ni/niployments/deployments/volumes-data/nijobs-beta:/usr/src/app/static'
-project_health_check_url[nijobs-be---develop]='https://localhost:${project_port[nijobs-be---develop]}/'
+project_health_check_url[nijobs-be---develop]="https://localhost:${project_port[nijobs-be---develop]}/"
 
 # debug example:
 # project_dotenv_location[nijobs-be---develop]='/home/miguel/Coding/NIAEFEUP/niployments/deployments/env-files/nijobs-be/develop/.env.local'

--- a/deployments/project-configs.sh
+++ b/deployments/project-configs.sh
@@ -12,6 +12,7 @@ configured_projects="Website-NIAEFEUP tts-fe nijobs-fe nijobs-be"
 declare -A project_port
 declare -A project_dotenv_location
 declare -A project_docker_flags
+declare -A project_health_check_url
 
 # Website-NIAEFEUP
 project_port[Website-NIAEFEUP---master]=3000
@@ -38,10 +39,13 @@ project_dotenv_location[nijobs-fe---experimental]='/home/ni/niployments/deployme
 project_port[nijobs-be---master]=4010
 project_dotenv_location[nijobs-be---master]='/home/ni/niployments/deployments/env-files/nijobs-be/master/.env.local'
 project_docker_flags[nijobs-be---master]='-v /home/ni/niployments/deployments/volumes-data/nijobs:/usr/src/app/static'
+project_health_check_url[nijobs-be---master]='https://localhost:${project_port[nijobs-be---master]}/'
 ## nijobs-be staging
 project_port[nijobs-be---develop]=4011
 project_dotenv_location[nijobs-be---develop]='/home/ni/niployments/deployments/env-files/nijobs-be/develop/.env.local'
 project_docker_flags[nijobs-be---develop]='-v /home/ni/niployments/deployments/volumes-data/nijobs-beta:/usr/src/app/static'
+project_health_check_url[nijobs-be---develop]='https://localhost:${project_port[nijobs-be---develop]}/'
+
 # debug example:
 # project_dotenv_location[nijobs-be---develop]='/home/miguel/Coding/NIAEFEUP/niployments/deployments/env-files/nijobs-be/develop/.env.local'
 
@@ -49,4 +53,5 @@ project_docker_flags[nijobs-be---develop]='-v /home/ni/niployments/deployments/v
 export project_port
 export project_dotenv_location
 export project_docker_flags
+export project_health_check_url
 export configured_projects


### PR DESCRIPTION
Closes #28 

Created a function to health check any web based service (via cURL)

This will try the configured endpoint for 5 minutes, on 10 second intervals. If the checks never return 200, the check fails and the new deployment rolls back (new container is removed, and old one is restarted)

Onboarded `nijobs-be` for this new feature in the project configs.